### PR TITLE
Allow "cmds" array parameter items to be dicts

### DIFF
--- a/expect_runner/expect_runner.py
+++ b/expect_runner/expect_runner.py
@@ -96,8 +96,11 @@ class ExpectRunner(ActionRunner):
             elif isinstance(cmd_tuple, str):
                 cmd = cmd_tuple
                 expect = default_expect
+            elif isinstance(cmd_tuple, dict):
+                cmd = cmd_tuple['cmd']
+                expect = cmd_tuple.get('expect', default_expect)
             else:
-                raise ValueError("Command error. Entry wasn't proper type (list or string)"
+                raise ValueError("Command error. Entry wasn't proper type (list, dict or string)"
                                  " or list was of incorrect length. %s" % (cmd_tuple))
 
             LOG.debug("Dispatching command: %s, %s", cmd, expect)

--- a/expect_runner/runner.yaml
+++ b/expect_runner/runner.yaml
@@ -25,6 +25,16 @@
           - type: string
           - type: array
           - type: object
+            properties:
+              cmd:
+                type: string
+                description: Command to run.
+                required: true
+              expect:
+                type: string
+                description: String to expect / wait on
+                required: false
+            additionalProperties: false
     expects:
       description: List of expects that match with cmds.
       type: array

--- a/expect_runner/runner.yaml
+++ b/expect_runner/runner.yaml
@@ -11,6 +11,19 @@
     cmds:
       description: List of commands to execute.
       type: array
+      # Items can either be arrays with two items where the first item is a command to execute
+      # and the second one is the expect command. For example:
+      # - ['show wireless ap configured', 'VX9000']
+      #
+      # Or an array where items are dictionaries / objects with two keys - "cmd" and "expect".
+      # For example:
+      # -
+      #   cmd: show wireless ap configured
+      #   expect: VX9000
+      items:
+        oneOf:
+          - type: string
+          - type: object
     expects:
       description: List of expects that match with cmds.
       type: array

--- a/expect_runner/runner.yaml
+++ b/expect_runner/runner.yaml
@@ -23,6 +23,7 @@
       items:
         oneOf:
           - type: string
+          - type: array
           - type: object
     expects:
       description: List of expects that match with cmds.

--- a/tests/unit/test_expect_runner.py
+++ b/tests/unit/test_expect_runner.py
@@ -45,6 +45,10 @@ MULTIPLE_COMMANDS = [
     ['two happy commands', '#']
 ]
 
+MULTIPLE_COMMANDS_DICT_ITEMS = [
+    {'cmd': 'one happy command'},
+    {'cmd': 'two happy command', 'expect': '#'},
+]
 NONE_EXPECT = [
     ['one happy command', None]
 ]
@@ -219,11 +223,22 @@ class ExpectRunnerTestCase(RunnerTestCase):
         self.assertTrue(output is not None)
         self.assertEqual(output['result'], None)
 
-    def test_multiple_cmds(self):
+    def test_multiple_cmds_as_array_of_arays(self):
         runner = expect_runner.get_runner()
         runner.action = self._get_mock_action_obj()
         runner.runner_parameters = copy.deepcopy(RUNNER_PARAMETERS)
         runner.runner_parameters['cmds'] = MULTIPLE_COMMANDS
+        runner.pre_run()
+        (status, output, _) = runner.run(None)
+        self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
+        self.assertTrue(output is not None)
+        self.assertEqual(output['result'], MOCK_OUTPUT * 2)
+
+    def test_multiple_cmds_as_array_of_dicts(self):
+        runner = expect_runner.get_runner()
+        runner.action = self._get_mock_action_obj()
+        runner.runner_parameters = copy.deepcopy(RUNNER_PARAMETERS)
+        runner.runner_parameters['cmds'] = MULTIPLE_COMMANDS_DICT_ITEMS
         runner.pre_run()
         (status, output, _) = runner.run(None)
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)


### PR DESCRIPTION
This pull request updates the runner so the actual items for ``cmds`` array parameter can also be dicts.

This way the following notations are supported.

1. Array of arrays:

```yaml
  cmds:
    description: Array of commands.
    immutable: true
    type: array
    default:
      - ['show wireless ap configured', '#']
```

2. Array of dicts:

```yaml
  cmds:
    description: Array of commands.
    immutable: true
    type: array
    default:
      -
        cmd: "show wireless ap configured"
        expect: "#"
```

This allows us to work around some edge cases where nested lists are not supported.