### PR TITLE
Fix pack config retrieval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ jobs:
           command: |
             make requirements
       - run:
-          name: Run lint and tests (Python 2.7)
+          name: Run lint and tests (Python 2.7 with coverage)
           command: |
             make .lint
-            make .unit-tests
+            make .unit-tests-coverage-ci
       - save_cache:
           key: v1-dependency-cache-py27-{{ checksum "/tmp/st2/requirements.txt" }}
           paths:

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ compile:
 	@echo
 	rm -f .coverage
 	rm -f coverage.xml
-	virtualenv/bin/coverage xml --rcfile=./../lint-configs/.coveragerc -i -o coverage.xml
+	virtualenv/bin/coverage xml --rcfile=./lint-configs/.coveragerc -i -o coverage.xml
 	. $(VIRTUALENV_DIR)/bin/activate; nosetests --with-cover --cover-erase --cover-tests --cover-package=expect_runner,tests $(NOSE_OPTS) -s -v tests/unit/
 	virtualenv/bin/codecov --file coverage.xml
 

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ compile:
 	@echo
 	rm -f .coverage
 	rm -f coverage.xml
-	virtualenv/bin/coverage xml --rcfile=./lint-configs/.coveragerc -i -o coverage.xml
 	. $(VIRTUALENV_DIR)/bin/activate; nosetests --with-cover --cover-erase --cover-tests --cover-package=expect_runner,tests $(NOSE_OPTS) -s -v tests/unit/
+	virtualenv/bin/coverage xml --rcfile=./lint-configs/.coveragerc -i -o coverage.xml
 	virtualenv/bin/codecov --file coverage.xml
 
 .PHONY: .clone_st2_repo

--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,23 @@ compile:
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v tests/unit/
 
-.PHONY: .unit-tests-py3
-.unit-tests-py3:
+.PHONY: .unit-tests-coverage
+.unit-tests-coverage:
 	@echo
-	@echo "==================== unit-tests-py3 ===================="
+	@echo "==================== unit-tests-coverage ===================="
 	@echo
-	NOSE_WITH_TIMER=$(NOSE_WITH_TIMER) tox -e py36-unit -vv
+	. $(VIRTUALENV_DIR)/bin/activate; nosetests --with-cover --cover-erase --cover-tests --cover-package=expect_runner,tests $(NOSE_OPTS) -s -v tests/unit/
+
+.PHONY: .unit-tests-coverage-ci
+.unit-tests-coverage-ci:
+	@echo
+	@echo "==================== unit-tests-coverage-ci ===================="
+	@echo
+	rm -f .coverage
+	rm -f coverage.xml
+	coverage xml --rcfile=./../lint-configs/.coveragerc -i -o coverage.xml
+	. $(VIRTUALENV_DIR)/bin/activate; nosetests --with-cover --cover-erase --cover-tests --cover-package=expect_runner,tests $(NOSE_OPTS) -s -v tests/unit/
+	virtualenv/bin/codecov --file coverage.xml
 
 .PHONY: .clone_st2_repo
 .clone_st2_repo: /tmp/st2
@@ -134,6 +145,7 @@ requirements: virtualenv .clone_st2_repo
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r /tmp/st2/requirements.txt
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r /tmp/st2/test-requirements.txt
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements.txt
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements-tests.txt
 
 .PHONY: requirements-ci
 requirements-ci:
@@ -143,6 +155,7 @@ requirements-ci:
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r /tmp/st2/requirements.txt
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r /tmp/st2/test-requirements.txt
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements.txt
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements-tests.txt
 
 .PHONY: virtualenv
 virtualenv: $(VIRTUALENV_DIR)/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ compile:
 	@echo
 	rm -f .coverage
 	rm -f coverage.xml
-	virtualenv/coverage xml --rcfile=./../lint-configs/.coveragerc -i -o coverage.xml
+	virtualenv/bin/coverage xml --rcfile=./../lint-configs/.coveragerc -i -o coverage.xml
 	. $(VIRTUALENV_DIR)/bin/activate; nosetests --with-cover --cover-erase --cover-tests --cover-package=expect_runner,tests $(NOSE_OPTS) -s -v tests/unit/
 	virtualenv/bin/codecov --file coverage.xml
 

--- a/Makefile
+++ b/Makefile
@@ -143,9 +143,8 @@ requirements: virtualenv .clone_st2_repo
 	@echo "==================== requirements ===================="
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r /tmp/st2/requirements.txt
-	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r /tmp/st2/test-requirements.txt
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements.txt
-	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements-tests.txt
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements-test.txt
 
 .PHONY: requirements-ci
 requirements-ci:
@@ -153,9 +152,8 @@ requirements-ci:
 	@echo "==================== requirements-ci ===================="
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r /tmp/st2/requirements.txt
-	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r /tmp/st2/test-requirements.txt
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements.txt
-	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements-tests.txt
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements-test.txt
 
 .PHONY: virtualenv
 virtualenv: $(VIRTUALENV_DIR)/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ compile:
 	@echo
 	rm -f .coverage
 	rm -f coverage.xml
-	coverage xml --rcfile=./../lint-configs/.coveragerc -i -o coverage.xml
+	virtualenv/coverage xml --rcfile=./../lint-configs/.coveragerc -i -o coverage.xml
 	. $(VIRTUALENV_DIR)/bin/activate; nosetests --with-cover --cover-erase --cover-tests --cover-package=expect_runner,tests $(NOSE_OPTS) -s -v tests/unit/
 	virtualenv/bin/codecov --file coverage.xml
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+codecov:
+  bot: ""
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2         # decimal places to display: 0 <= value <= 4
+  round: nearest
+  range: 50...90      # custom range of coverage colors from red -> yellow -> green
+
+  status:
+    project:
+      default:
+        default: false
+        # TODO: Define threshold once we actually have some tests
+        #target: auto
+        #threshold: 2%
+        #patch: yes
+
+# NOTE: We ignore all the auto-generated and test files
+ignore:
+  - ".*/tests/.*"
+  - ".*/generated/.*"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: yes
+  require_head: yes

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,11 +11,9 @@ coverage:
   status:
     project:
       default:
-        default: false
-        # TODO: Define threshold once we actually have some tests
-        #target: auto
-        #threshold: 2%
-        #patch: yes
+        threshold: 2%
+    patch: yes
+    changes: no
 
 # NOTE: We ignore all the auto-generated and test files
 ignore:
@@ -26,5 +24,3 @@ comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false
-  require_base: yes
-  require_head: yes

--- a/expect_runner/expect_runner.py
+++ b/expect_runner/expect_runner.py
@@ -24,7 +24,6 @@ import paramiko
 from st2common.runners.base import ActionRunner
 from st2common.runners.base import get_metadata as get_runner_metadata
 from st2common import log as logging
-from st2common.util.config_loader import ContentPackConfigLoader
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
 from st2common.constants.action import LIVEACTION_STATUS_FAILED
 from st2common.constants.action import LIVEACTION_STATUS_TIMED_OUT
@@ -62,8 +61,8 @@ def _expect_return(expect, output):
     return re.search(expect, output) is not None
 
 
-def get_runner():
-    return ExpectRunner(str(uuid.uuid4()))
+def get_runner(config=None):
+    return ExpectRunner(str(uuid.uuid4()), config=config)
 
 
 def get_metadata():
@@ -71,6 +70,11 @@ def get_metadata():
 
 
 class ExpectRunner(ActionRunner):
+    def __init__(self, runner_id, config=None):
+        super(ExpectRunner, self).__init__(runner_id=runner_id)
+
+        self._config = config or {}
+
     def _parse(self, output):
         model = tatsu.compile(self._grammar)
         parsed_output = model.parse(output, start=self._entry)
@@ -122,25 +126,6 @@ class ExpectRunner(ActionRunner):
             'Entering ExpectRunner.PRE_run() for liveaction_id="%s"',
             self.liveaction_id
         )
-
-        self._config = {
-            'init_cmds': [],
-            'default_expect': None
-        }
-
-        pack = self.get_pack_name()
-        user = self.get_user()
-
-        LOG.debug("Parsing config: %s, %s", pack, user)
-        config_loader = ContentPackConfigLoader(pack_name=pack, user=user)
-        config = config_loader.get_config()
-
-        if config:
-            LOG.debug("Loading pack config.")
-            self._config['init_cmds'] = config.get('init_cmds', [])
-            self._config['default_expect'] = config.get('default_expect', None)
-        else:
-            LOG.debug("No pack config found.")
 
         LOG.debug("Config: %s", self._config)
 

--- a/expect_runner/expect_runner.py
+++ b/expect_runner/expect_runner.py
@@ -17,6 +17,7 @@ import time
 import socket
 import re
 import json
+import copy
 
 import tatsu
 import paramiko
@@ -73,7 +74,12 @@ class ExpectRunner(ActionRunner):
     def __init__(self, runner_id, config=None):
         super(ExpectRunner, self).__init__(runner_id=runner_id)
 
-        self._config = config or {}
+        config = copy.deepcopy(config) or {}
+        self._config = {
+            'init_cmds': config.pop('init_cmds', []),
+            'default_expect': config.pop('default_expect', None)
+        }
+        self._config.update(config)
 
     def _parse(self, output):
         model = tatsu.compile(self._grammar)

--- a/lint-configs/.coveragerc
+++ b/lint-configs/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit =
+    */generated/*
+
+[report]
+omit =
+    */generated/*

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ unittest2
 rednose
 nose-timer==0.7.5
 psutil==5.6.3
+codecov==2.0.15


### PR DESCRIPTION
Currently this runner manually retrieves pack config inside the runner code.

This is likely very old and legacy approach since for a long time now, runners received config values as a runner constructor argument.

This pull request updates the runner to follow this new config retrieval approach which means the runner code itself now also doesn't depend on the database connection anymore (that was the case with the previous version of the code).

In short - it makes the runner to comply with the current "standard" runner interface.